### PR TITLE
[WIP] Add support for stack --nix and nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+with import <nixpkgs> {};
+
+stdenv.mkDerivation rec {
+  name = "env";
+
+  env = buildEnv {
+    name  = name;
+    paths = buildInputs;
+  };
+
+  buildInputs = [
+    ghc
+    zlib
+  ];
+
+  shellHook = ''
+    export LD_LIBRARY_PATH="${zlib}/lib/"
+  '';
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,4 +7,4 @@ packages:
   - '.'
 
 ghc-options:
-  "$locals": -Wall
+  "$locals": -Wall -Werror

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,10 @@
 resolver: lts-10.3
 
+nix:
+  packages: [zlib]
+
 packages:
   - '.'
 
 ghc-options:
-  "$locals": -Wall -Werror
+  "$locals": -Wall


### PR DESCRIPTION
This PR adds the requisite nix `packages` stanza to `stack.yaml` allowing `stack install --nix pier` to succeed, as well as adding a minimal `shell.nix` derivation to allow `pier build pier` to succeed (within the shell).

Steps taken to build `pier` using `pier` are as follows:

```
$ stack install --nix pier
$ nix-shell
```

```
nix-shell$ mkdir tmp
nix-shell$ TMPDIR=$PWD/tmp pier build pier
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/pier/68)
<!-- Reviewable:end -->
