### PR TITLE
Drop trailing slashes in normalization.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ references:
         - run:
             command: |
               $(${STACK} exec which pier) build -j4 \
-                  c2hs elm-core-sources hscolour hsndfile hsx2hs lens \
+                  c2hs direct-sqlite elm-core-sources hscolour hsndfile hsx2hs lens \
                   network-multicast pandoc pier unix-time wreq xhtml yaml \
                   X11-xft
         - run: $(${STACK} exec which pier) build # also build pier's examples

--- a/src/Pier/Core/Artifact.hs
+++ b/src/Pier/Core/Artifact.hs
@@ -215,9 +215,9 @@ instance Applicative Output where
 -- The input must be a relative path and nontrivial (i.e., not @"."@ or @""@).
 output :: FilePath -> Output Artifact
 output f
-    | normalise f == "." = error $ "Can't output empty path " ++ show f
+    | normaliseMore f == "." = error $ "Can't output empty path " ++ show f
     | isAbsolute f = error $ "Can't output absolute path " ++ show f
-    | otherwise = Output [f] $ flip Artifact (normalise f) . Built
+    | otherwise = Output [f] $ flip Artifact (normaliseMore f) . Built
 
 -- | Unique identifier of a command
 newtype Hash = Hash B.ByteString
@@ -273,12 +273,16 @@ externalFile f
     | artifactDir `List.isPrefixOf` f' = error $ "externalFile: forbidden prefix: " ++ show f'
     | otherwise = Artifact External f'
   where
-    f' = normalise f
+    f' = normaliseMore f
+
+-- | Normalize a filepath, also dropping the trailing slash.
+normaliseMore :: FilePath -> FilePath
+normaliseMore = dropTrailingPathSeparator . normalise
 
 -- | Create a reference to a sub-file of the given 'Artifact', which must
 -- refer to a directory.
 (/>) :: Artifact -> FilePath -> Artifact
-Artifact source f /> g = Artifact source $ normalise $ f </> g
+Artifact source f /> g = Artifact source $ normaliseMore $ f </> g
 
 infixr 5 />  -- Same as </>
 
@@ -661,7 +665,7 @@ writeArtifactRules = addPersistent
         let out = tmpDir </> path
         createParentIfMissing out
         liftIO $ writeFile out contents
-    return $ Artifact (Built h) $ normalise path
+    return $ Artifact (Built h) $ normaliseMore path
 
 doesArtifactExist :: Artifact -> Action Bool
 doesArtifactExist (Artifact External f) = Development.Shake.doesFileExist f

--- a/src/Pier/Core/Directory.hs
+++ b/src/Pier/Core/Directory.hs
@@ -8,5 +8,14 @@ import System.Directory
 
 -- | Create recursively the parent of the given path, if it doesn't exist.
 createParentIfMissing :: MonadIO m => FilePath -> m ()
-createParentIfMissing path
-    = liftIO $ createDirectoryIfMissing True (takeDirectory path)
+createParentIfMissing
+    = liftIO . createDirectoryIfMissing True . parentDirectory
+
+-- | Get the parent of the given directory or file.
+--
+-- Examples:
+--
+-- parentDirectory "foo/bar"  == "foo"
+-- parentDirectory "foo/bar/" == "foo"
+parentDirectory :: FilePath -> FilePath
+parentDirectory = takeDirectory . dropTrailingPathSeparator


### PR DESCRIPTION
Fixes build of `direct-sqlite`, which:
1. Has an `hsc` file, and
2. Specifies `include-dirs: .`

The main problem was that `System.FilePath.normalise` does not drop the
trailing slash from files.  This causes problems, including:
- `takeDirectory "abc/def/" == "abc/def"`, not `"abc/"`
- `createSymbolicLink ... "abc/def/" ` with the trailing slash doesn't
  seem to work as expected, but instead tries to create a symbolic link in the
  directory `"abc/def/"`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/pier/97)
<!-- Reviewable:end -->
