### PR TITLE
Update to lts-12.8.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 references:
     build-base: &build-base
       docker:
-        - image: judah/pier-ci:v1
+        - image: judah/pier-ci:v2
       steps:
         - checkout
         - run: echo "${STACK}" > stack-env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,12 +54,15 @@ jobs:
     <<: *build-base
     environment:
       - STACK: "stack"
-      - EXAMPLE_RESOLVER: "lts-10.3"
-  build-nightly:
-    <<: *build-base
-    environment:
-      - STACK: "stack --resolver=nightly-2018-05-05"
-      - EXAMPLE_RESOLVER: "nightly-2018-05-05"
+      - EXAMPLE_RESOLVER: "lts-12.8"
+  # Note: more builds may be added here and made
+  # requirements of build-success.
+  # For example:
+  # build-nightly:
+  #  <<: *build-base
+  #  environment:
+  #    - STACK: "stack --resolver=nightly-2018-05-05"
+  #    - EXAMPLE_RESOLVER: "nightly-2018-05-05"
   build-success:
     docker:
       - image: judah/pier-ci:v1
@@ -71,8 +74,6 @@ workflows:
   build-and-test:
       jobs:
         - build
-        - build-nightly
         - build-success:
             requires:
               - build
-              - build-nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,13 @@ references:
         # Run pier on some sample packages
         - run:
             command: |
-              $(stack exec which pier) build -j4 \
-                  c2hs elm-core-sources hscolour hsndfile hsx2hs lens \
-                  network-multicast pandoc pier unix-time wreq xhtml yaml \
+               $(stack exec which pier) build -j4 \
+                  --shake-arg=--keep-going \
+                  --pier-yaml=test-package-config.yaml \
+                  c2hs elm-core-sources hscolour hsndfile lens \
+                  network-multicast pandoc unix-time wreq xhtml yaml \
                   X11-xft
-        - run: $(stack exec which pier) build # also build pier's examples
+        - run: $(stack exec which pier) build
         - run: $(stack exec which pier) run -j4 hlint --sandbox $PWD/src
         - run: $(stack exec which pier) run hlint src
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,25 +6,24 @@ references:
         - image: judah/pier-ci:v2
       steps:
         - checkout
-        - run: echo "${STACK}" > stack-env
         - restore_cache:
             keys:
-              - stack-cache-v4-{{ checksum "stack-env" }}-{{ arch }}-{{ .Branch }}
-              - stack-cache-v4-{{ checksum "stack-env" }}-{{ arch }}-master
+              - stack-cache-v5-{{ arch }}-{{ .Branch }}
+              - stack-cache-v5-{{ arch }}-master
         - run:
             command: |
               echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
 
         # Build with `stack`
-        - run: ${STACK} --no-terminal install weeder hlint
-        - run: ${STACK} --no-terminal build --only-dependencies --fast --no-terminal
-        - run: ${STACK} --no-terminal build --pedantic --fast --no-terminal
+        - run: stack --no-terminal install weeder hlint
+        - run: stack --no-terminal build --only-dependencies --fast --no-terminal
+        - run: stack --no-terminal build --pedantic --fast --no-terminal
 
         - run: hlint .
         - run: weeder . --build
 
         - save_cache:
-              key: stack-cache-v4-{{ checksum "stack-env" }}-{{ arch }}-{{ .Branch }}-{{ epoch }}
+              key: stack-cache-v5-{{ arch }}-{{ .Branch }}-{{ epoch }}
               paths:
                   - ~/.stack
                   - .stack-work
@@ -32,48 +31,24 @@ references:
         # Run pier on some sample packages
         - run:
             command: |
-              $(${STACK} exec which pier) build -j4 \
+              $(stack exec which pier) build -j4 \
                   c2hs elm-core-sources hscolour hsndfile hsx2hs lens \
                   network-multicast pandoc pier unix-time wreq xhtml yaml \
                   X11-xft
-        - run: $(${STACK} exec which pier) build # also build pier's examples
-        - run: $(${STACK} exec which pier) run -j4 hlint --sandbox $PWD/src
-        - run: $(${STACK} exec which pier) run hlint src
+        - run: $(stack exec which pier) build # also build pier's examples
+        - run: $(stack exec which pier) run -j4 hlint --sandbox $PWD/src
+        - run: $(stack exec which pier) run hlint src
         - run:
             command: |
-                cat > example/pier-example.yaml <<EOF
-                system-ghc: true
-                resolver: ${EXAMPLE_RESOLVER}
-                packages:
-                - '.'
-                EOF
-        - run: ${STACK} exec pier -- build --pier-yaml=example/pier-example.yaml text unix-compat
+                echo "system-ghc: true" >> example/pier.yaml
+        - run: stack exec pier -- build --pier-yaml=example/pier.yaml text unix-compat
 
 jobs:
   build:
     <<: *build-base
-    environment:
-      - STACK: "stack"
-      - EXAMPLE_RESOLVER: "lts-12.8"
-  # Note: more builds may be added here and made
-  # requirements of build-success.
-  # For example:
-  # build-nightly:
-  #  <<: *build-base
-  #  environment:
-  #    - STACK: "stack --resolver=nightly-2018-05-05"
-  #    - EXAMPLE_RESOLVER: "nightly-2018-05-05"
-  build-success:
-    docker:
-      - image: judah/pier-ci:v1
-    steps:
-      - run: echo success
 
 workflows:
   version: 2
   build-and-test:
       jobs:
         - build
-        - build-success:
-            requires:
-              - build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,15 @@ FROM ubuntu:16.04
 
 ENV LANG C.UTF-8
 
-RUN apt-get update
-RUN apt-get -y install curl libgmp3-dev libsndfile1-dev libxft-dev libxrandr-dev
+RUN \
+    apt-get update && \
+    apt-get -y install \
+        curl \
+        libgmp3-dev \
+        libsndfile1-dev \
+        libxft-dev \
+        libxrandr-dev \
+        libxss-dev
+
 RUN mkdir -p $HOME/.local/bin
 RUN curl -L https://github.com/commercialhaskell/stack/releases/download/v1.7.1/stack-1.7.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,4 +5,4 @@ ENV LANG C.UTF-8
 RUN apt-get update
 RUN apt-get -y install curl libgmp3-dev libsndfile1-dev libxft-dev libxrandr-dev
 RUN mkdir -p $HOME/.local/bin
-RUN curl -L https://github.com/commercialhaskell/stack/releases/download/v1.6.1/stack-1.6.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
+RUN curl -L https://github.com/commercialhaskell/stack/releases/download/v1.7.1/stack-1.7.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'

--- a/example/pier.yaml
+++ b/example/pier.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.3
+resolver: lts-12.8
 
 packages:
   - '.'

--- a/package.yaml
+++ b/package.yaml
@@ -10,15 +10,14 @@ category: Development
 github: judah/pier
 
 dependencies:
-  - base
-  - directory
-  - Cabal
+  - base >= 4.11.0
+  - directory >= 1.3.1
+  - Cabal >= 2.2.0.0
   - shake
   - unordered-containers
 
 default-extensions:
   - BangPatterns
-  - CPP
   - DeriveGeneric
   - FlexibleContexts
   - LambdaCase
@@ -49,10 +48,6 @@ library:
     - text
     - transformers
     - yaml
-  when:
-    - condition: "!os(windows)"
-      dependencies:
-        - unix
 
 # Work around haskell/cabal#4739
 when:

--- a/pier.yaml
+++ b/pier.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.3
+resolver: lts-12.8
 
 packages:
   - '.'

--- a/src/Pier/Build/CFlags.hs
+++ b/src/Pier/Build/CFlags.hs
@@ -8,9 +8,6 @@ module Pier.Build.CFlags
 
 import Control.Applicative (liftA2)
 import Control.Monad (guard)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup (Semigroup(..))
-#endif
 import Data.Set (Set)
 import Development.Shake
 import Development.Shake.Classes

--- a/src/Pier/Build/Components.hs
+++ b/src/Pier/Build/Components.hs
@@ -12,9 +12,6 @@ module Pier.Build.Components
 import Control.Applicative (liftA2)
 import Control.Monad (filterM)
 import Data.List (find)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Development.Shake
 import Development.Shake.Classes
 import Development.Shake.FilePath hiding (exe)

--- a/src/Pier/Build/Components.hs
+++ b/src/Pier/Build/Components.hs
@@ -12,6 +12,7 @@ module Pier.Build.Components
 import Control.Applicative (liftA2)
 import Control.Monad (filterM)
 import Data.List (find)
+import Data.Maybe (fromMaybe)
 import Development.Shake
 import Development.Shake.Classes
 import Development.Shake.FilePath hiding (exe)
@@ -382,10 +383,9 @@ renderReexport deps re = display (moduleReexportName re) ++ " from "
                     ++ display (moduleReexportOriginalName re)
   where
     originalPkg p =
-        case Map.lookup p deps of
-            Nothing -> error $ "Unknown package name " ++ display p
-                        ++ " for module reexport " ++ display re
-            Just pkg -> pkg
+        fromMaybe (error $ "Unknown package name " ++ display p
+                                ++ " for module reexport " ++ display re)
+            $ Map.lookup p deps
 
 collectInstallIncludes :: Artifact -> BuildInfo -> Action (Maybe Artifact)
 collectInstallIncludes dir bi

--- a/src/Pier/Build/Components.hs
+++ b/src/Pier/Build/Components.hs
@@ -11,7 +11,7 @@ module Pier.Build.Components
 
 import Control.Applicative (liftA2)
 import Control.Monad (filterM)
-import Data.List (find)
+import Data.List (find, intercalate)
 import Development.Shake
 import Development.Shake.Classes
 import Development.Shake.FilePath hiding (exe)
@@ -333,6 +333,8 @@ registerPackage ghc pkg bi cflags maybeLib (BuiltDeps depPkgs transDeps)
                   , "import-dirs: ${pkgroot}" </> pre </> "hi"
                   , "exposed-modules: " ++ unwords (map display $ exposedModules lib)
                   , "hidden-modules: " ++ unwords (map display $ otherModules bi)
+                  , "reexported-modules: " ++
+                        intercalate ", " (map display $ reexportedModules lib)
                   ]
                 )
     spec <- writeArtifact "spec" $ unlines $

--- a/src/Pier/Build/Custom.hs
+++ b/src/Pier/Build/Custom.hs
@@ -9,9 +9,6 @@ module Pier.Build.Custom
     ) where
 
 import Data.Char (isDigit)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Development.Shake
 import Development.Shake.FilePath
 import Distribution.PackageDescription

--- a/src/Pier/Build/Executable.hs
+++ b/src/Pier/Build/Executable.hs
@@ -6,9 +6,6 @@ module Pier.Build.Executable
     , progExe
     ) where
 
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Data.Set (Set)
 import Development.Shake
 import Development.Shake.Classes

--- a/src/Pier/Build/Module.hs
+++ b/src/Pier/Build/Module.hs
@@ -114,7 +114,7 @@ search ghc flags m srcDir
         happy <- lift $ askBuiltExecutable (mkPackageName "happy") "happy"
         lift . runCommand (output relOutput)
              $ progExe happy
-                     ["-o", relOutput, pathIn yFile]
+                     ["-agc", "-o", relOutput, pathIn yFile]
                 <> input yFile
 
     genHsc2hs = do
@@ -140,7 +140,7 @@ search ghc flags m srcDir
         alex <- lift $ askBuiltExecutable (mkPackageName "alex") "alex"
         lift . runCommand (output relOutput)
             $ progExe alex
-                     ["-o", relOutput, pathIn xFile]
+                     ["-g", "-o", relOutput, pathIn xFile]
                <> input xFile
     genC2hs = do
         let chsFile = srcDir /> toFilePath m <.> "chs"

--- a/src/Pier/Build/Module.hs
+++ b/src/Pier/Build/Module.hs
@@ -10,9 +10,6 @@ import Control.Monad (guard, msum)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe
 import Data.List (intercalate)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Development.Shake
 import Distribution.ModuleName
 import Distribution.Package (PackageIdentifier(..), mkPackageName)

--- a/src/Pier/Build/Package.hs
+++ b/src/Pier/Build/Package.hs
@@ -11,11 +11,7 @@ import Development.Shake.FilePath
 import Distribution.Compiler
 import Distribution.Package
 import Distribution.PackageDescription
-#if MIN_VERSION_Cabal(2,2,0)
 import Distribution.PackageDescription.Parsec
-#else
-import Distribution.PackageDescription.Parse
-#endif
 import Distribution.System (buildOS, buildArch)
 import Distribution.Text (display)
 import Distribution.Types.CondTree (CondBranch(..))
@@ -52,11 +48,7 @@ configurePackage plan flags packageSourceDir = do
     let desc = flattenToDefaultFlags plan flags gdesc
     let name = display (packageName desc)
     case buildType desc of
-#if MIN_VERSION_Cabal(2,2,0)
         Configure -> do
-#else
-        Just Configure -> do
-#endif
             let configuredDir = name
             configuredPackage <- runCommand (output configuredDir)
                 $ shadow packageSourceDir configuredDir
@@ -77,34 +69,19 @@ configurePackage plan flags packageSourceDir = do
 parseCabalFileInDir :: Artifact -> Action GenericPackageDescription
 parseCabalFileInDir dir = do
     cabalFile <- findCabalFile dir
-#if MIN_VERSION_Cabal(2,2,0)
     cabalContents <- readArtifactB cabalFile
     -- TODO: better error message when parse fails; and maybe warnings too?
     case runParseResult $ parseGenericPackageDescription cabalContents of
         (_, Right pkg) -> return pkg
         e -> error $ show e ++ "\n" ++ show cabalContents
-#else
-    cabalContents <- readArtifact cabalFile
-    case parseGenericPackageDescription cabalContents of
-        ParseFailed err -> error $ show err ++ "\n" ++ cabalContents
-        ParseOk _ pkg -> return pkg
-#endif
 
 readHookedBuildInfoA :: Artifact -> Action HookedBuildInfo
 readHookedBuildInfoA file = do
-#if MIN_VERSION_Cabal(2,2,0)
     hookedBIParse <- parseHookedBuildInfo <$> readArtifactB file
     case runParseResult hookedBIParse of
         (_,Right hookedBI) -> return hookedBI
         e -> error $ "Error reading buildinfo " ++ show file
                                                     ++ ": " ++ show e
-#else
-    hookedBIParse <- parseHookedBuildInfo <$> readArtifact file
-    case hookedBIParse of
-        ParseFailed e -> error $ "Error reading buildinfo " ++ show file
-                                                    ++ ": " ++ show e
-        ParseOk _ hookedBI -> return hookedBI
-#endif
 
 findCabalFile :: Artifact -> Action Artifact
 findCabalFile dir = do

--- a/src/Pier/Core/Artifact.hs
+++ b/src/Pier/Core/Artifact.hs
@@ -81,9 +81,6 @@ import Control.Monad (forM_, when, unless)
 import Control.Monad.IO.Class
 import Crypto.Hash.SHA256
 import Data.ByteString.Base64
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup (Semigroup(..))
-#endif
 import Data.Set (Set)
 import Development.Shake
 import Development.Shake.Classes hiding (hash)
@@ -92,9 +89,6 @@ import Distribution.Simple.Utils (matchDirFileGlob)
 import GHC.Generics
 import System.Directory as Directory
 import System.Exit (ExitCode(..))
-#if !MIN_VERSION_directory(1,3,1)
-import System.Posix.Files (createSymbolicLink)
-#endif
 import System.Process.Internals (translate)
 
 import qualified Data.Binary as Binary
@@ -294,12 +288,6 @@ createExternalLink = do
     unless exists $ do
         createParentIfMissing externalArtifactDir
         createDirectoryLink "../.." externalArtifactDir
-
-#if !MIN_VERSION_directory(1,3,1)
-createFileLink, createDirectoryLink :: FilePath -> FilePath -> IO ()
-createFileLink = createSymbolicLink
-createDirectoryLink = createSymbolicLink
-#endif
 
 -- | The build rule type for commands.
 data CommandQ = CommandQ

--- a/src/Pier/Orphans.hs
+++ b/src/Pier/Orphans.hs
@@ -21,9 +21,6 @@ instance Hashable a => Hashable (Set.Set a) where
     hashWithSalt k = hashWithSalt k . Set.toList
 
 instance Hashable FlagName
-#if !MIN_VERSION_Cabal(2,2,0)
-instance NFData FlagName
-#endif
 instance Hashable PackageId
 instance Hashable PackageName
 instance Hashable ComponentId

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.7
+resolver: lts-12.8
 
 packages:
   - '.'

--- a/test-package-config.yaml
+++ b/test-package-config.yaml
@@ -1,0 +1,9 @@
+resolver: lts-12.8
+
+# Older packages that we'd still like to test, but haven't made it
+# into the latest LTS.
+extra-deps:
+# Uses c2hs:
+- hsndfile-0.8.0
+# Has old `Cabal-version` and an executable with no explicit build-depends:
+- hsx2hs-0.14.1.3


### PR DESCRIPTION
Updates all resolvers to `lts-12.8` and also removes the nightly build.  Also removes all CPP (`MIN_VERSION_*`).

Also fix related issues:
- Add module reexports, fixing `skylighting` (and `pandoc` which depends on it and uses a reexport)
- Update the Docker image with `stack-1.7.1` and `libxss-dev`
- Fix #89 (`haskell-src-exts` not building) by passing GHC-specific flags to `happy` and `alex`
- Give better names to package databases, to make debugging easier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/pier/102)
<!-- Reviewable:end -->
