### PR TITLE
 Be more explicit about the executable targets.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -151,11 +151,23 @@ pier run --help
 | `pier build {PACKAGE}:exe:{NAME}` | A specific executable in the given package. |
 
 ### `pier run`
-`pier run {TARGET} {ARGUMENTS}` builds the given target, and then runs it with the given command-line arguments.  `{TARGET}` should be a specific executable (for example, `pier:exe:pier`), which may be elided to a package if it contains an executable of the same name (for example, `pier`).
+`pier run {TARGET} {ARGUMENTS}` builds the given executable target, and then runs it with the given command-line arguments.  `{TARGET}` should be a specific executable; either:
+
+| Command | Result |
+| --- | --- |
+| `pier run {PACKAGE}:exe:{NAME}` | A specific executable from the given package. |
+| `pier run {NAME}` | Equivalent to `pier run {NAME}:exe:{NAME}`; an executable from a package of the same name. |
+
+For example, `pier run foo` is equivalent to `pier run foo:exe:foo`.  Note that
+this behavior differs from Stack, which is less explicit: `stack exec foo` may
+run a binary named `foo` from *any* previously built package.
 
 By default, the command will run in the same directory where `pier.yaml` is located.  To run in a temporary, hermetic directory, use `pier run --sandbox`.
 
 In case of ambiguity, `--` can be used to separate arguments of `pier` from arguments of the target.
+
+### `pier which`
+`pier which {TARGET}` builds the given executable target and then prints its location.  See the documentation of `pier run` for details on the syntax of `{TARGET}`.
 
 ### `pier clean`
 `pier clean` marks some metadata in the Shake database as "dirty", so that it will be recreated on the next build.  This command may be required if you build a new version of `pier`, but should be unnecessary otherwise.

--- a/Readme.md
+++ b/Readme.md
@@ -145,9 +145,9 @@ pier run --help
 | Command | Targets |
 | --- | --- |
 | `pier build` | All the libraries and executables for every entry in `packages`. |
-| `pier build {PACKAGE}` | The library and executables (if any) for the given package.  For example: `text` or `pier`.  `{PACKAGE}` can be a local package, one from the LTS, or one specified in `extra-deps`. |
+| `pier build {PACKAGE}` | The library and executables (if any) for the given package.<br>For example: `text` or `pier`.  `{PACKAGE}` can be a local package,<br>one from the LTS, or one specified in `extra-deps`. |
 | `pier build {PACKAGE}:lib` | The library for the given package. |
-| `pier build {PACKAGE}:exe` | The executables for the given package, but not the library (unless it is a dependency of one of them). |
+| `pier build {PACKAGE}:exe` | The executables for the given package, but not the library<br>(unless it is a dependency of one of them). |
 | `pier build {PACKAGE}:exe:{NAME}` | A specific executable in the given package. |
 
 ### `pier run`
@@ -156,13 +156,13 @@ pier run --help
 | Command | Result |
 | --- | --- |
 | `pier run {PACKAGE}:exe:{NAME}` | A specific executable from the given package. |
-| `pier run {NAME}` | Equivalent to `pier run {NAME}:exe:{NAME}`; an executable from a package of the same name. |
+| `pier run {NAME}` | Equivalent to `pier run {NAME}:exe:{NAME}`;<br>an executable from a package of the same name. |
 
 For example, `pier run foo` is equivalent to `pier run foo:exe:foo`.  Note that
 this behavior differs from Stack, which is less explicit: `stack exec foo` may
 run a binary named `foo` from *any* previously built package.
 
-By default, the command will run in the same directory where `pier.yaml` is located.  To run in a temporary, hermetic directory, use `pier run --sandbox`.
+By default, the executable will run in the same directory where `pier.yaml` is located.  To run in a temporary, hermetic directory, use `pier run --sandbox`.
 
 In case of ambiguity, `--` can be used to separate arguments of `pier` from arguments of the target.
 


### PR DESCRIPTION
In response to the question from #93, be more explicit about the syntax of `pier run` and add a note about the differences to `stack run/which`.

Also fix the formatting of the `pier build` targets table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/pier/105)
<!-- Reviewable:end -->
