### PR TITLE
Fix #90: Don't use '-' in the base64-encoding of hashes.

### DIFF
--- a/src/Pier/Core/Artifact.hs
+++ b/src/Pier/Core/Artifact.hs
@@ -221,10 +221,8 @@ makeHash :: Binary a => a -> Hash
 makeHash = Hash . fixChars . dropPadding . encode . hashlazy . Binary.encode
   where
     -- Remove slashes, since the strings will appear in filepaths.
-    -- Also remove `+` to reduce shell errors.
     fixChars = BC.map $ \case
-                                '/' -> '-'
-                                '+' -> '.'
+                                '/' -> '_'
                                 c -> c
     -- Padding just adds noise, since we don't have length requirements (and indeed
     -- every sha256 hash is 32 bytes)


### PR DESCRIPTION
Pier now uses '+' and '_' as the two non-alphanumeric characters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/pier/106)
<!-- Reviewable:end -->
