### PR TITLE
Don't autogenerate Cabal macros.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -238,7 +238,7 @@ If necessary, `pier clean-all` will delete the `_pier` folder (and thus wipe out
 - Downloads Stackage's build plans from `github.com/fpco`, and uses them to get the version numbers for the packages in that plan and for GHC.
 - Downloads GHC releases from `github.com/commercialhaskell`, getting the exact download location from a file hosted by `github.com/stackage`.
 - Downloads individual Haskell packages directly from Hackage.
-- Uses the `Cabal` library to parse the `.cabal` file format for each package, and to generate CPP version macros (for example, `MIN_VERSION_{package}`).
+- Uses the `Cabal` library to parse the `.cabal` file format for each package.
 
 In particular, it does not:
 

--- a/src/Pier/Build/Components.hs
+++ b/src/Pier/Build/Components.hs
@@ -267,7 +267,6 @@ ghcCommand ghc (BuiltDeps depPkgs transDeps) confd tinfo args
     = inputs (transitiveDBs transDeps)
         <> inputs (transitiveLibFiles transDeps)
         <> inputList (targetSourceInputs tinfo ++ targetOtherInputs tinfo)
-        <> input (confdMacros confd)
         -- Embed extra-source-files two ways: as regular inputs, and shadowed
         -- directly into the working directory.
         -- They're needed as regular inputs so that, if they're headers, they
@@ -301,7 +300,6 @@ ghcCommand ghc (BuiltDeps depPkgs transDeps) confd tinfo args
         ++ map ("-I" ++) (targetIncludeDirs tinfo)
         ++ targetOptions tinfo
         ++ map ("-optP" ++) (cppFlags cflags)
-        ++ ["-optP-include", "-optP" ++ pathIn (confdMacros confd)]
         ++ ["-optc" ++ opt | opt <- ccFlags cflags]
         ++ ["-l" ++ libDep | libDep <- linkLibs cflags]
         ++ ["-optl" ++ f | f <- linkFlags cflags]


### PR DESCRIPTION
GHC generates them automatically as of version 8.0.

Additionally, it looks like recent versions of Pandoc don't need the
single-macro-file-for-library-and-executables hack anymore.

This should resolve the build of `aeson` for #95.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/pier/112)
<!-- Reviewable:end -->
