### PR TITLE
Explicitly set LANG to UTF-8.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 references:
     build-base: &build-base
       docker:
-        - image: judah/pier-ci:v2
+        - image: judah/pier-ci:v3
       steps:
         - checkout
         - restore_cache:

--- a/.circleci/test-packages.txt
+++ b/.circleci/test-packages.txt
@@ -8,6 +8,7 @@ hsx2hs
 lens
 network-multicast
 pandoc
+publicsuffix
 unix-time
 wreq
 xhtml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:16.04
 
-ENV LANG C.UTF-8
-
 RUN \
     apt-get update && \
     apt-get -y install \
@@ -10,7 +8,8 @@ RUN \
         libsndfile1-dev \
         libxft-dev \
         libxrandr-dev \
-        libxss-dev
+        libxss-dev \
+        locales && \
+    locale-gen en_US.UTF-8
 
-RUN mkdir -p $HOME/.local/bin
-RUN curl -L https://github.com/commercialhaskell/stack/releases/download/v1.7.1/stack-1.7.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
+RUN curl -L https://github.com/commercialhaskell/stack/releases/download/v1.7.1/stack-1.7.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C /usr/local/bin '*/stack'

--- a/src/Pier/Core/Artifact.hs
+++ b/src/Pier/Core/Artifact.hs
@@ -590,7 +590,11 @@ stdoutOutput :: FilePath
 stdoutOutput = "_stdout"
 
 defaultEnv :: [(String, String)]
-defaultEnv = [("PATH", "/usr/bin:/bin")]
+defaultEnv =
+    [ ("PATH", "/usr/bin:/bin")
+    -- Set LANG to enable TemplateHaskell code reading UTF-8 files correctly.
+    , ("LANG", "en_US.UTF-8")
+    ]
 
 spliceTempDir :: FilePath -> String -> String
 spliceTempDir tmp = T.unpack . T.replace (T.pack "${TMPDIR}") (T.pack tmp) . T.pack

--- a/src/Pier/Core/Artifact.hs
+++ b/src/Pier/Core/Artifact.hs
@@ -100,6 +100,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.Text.Encoding.Error as T hiding (replace)
 
 import Pier.Core.Directory
 import Pier.Core.Persistent
@@ -516,19 +517,20 @@ readProgCall dir p as cwd = do
                     , EchoStderr False
                     ]
                     p' (map (spliceTempDir dir) as)
+    let errStr = T.unpack . T.decodeUtf8With T.lenientDecode $ err
     case ret of
         ExitSuccess -> return out
         ExitFailure ec -> do
             v <- shakeVerbosity <$> getShakeOptions
             fail $ if v < Loud
                 -- TODO: remove trailing newline
-                then err
+                then errStr
                 else unlines
                         [ showProg (ProgCall p as cwd)
                         , "Working dir: " ++ translate (dir </> cwd)
                         , "Exit code: " ++ show ec
                         , "Stderr:"
-                        , err
+                        , errStr
                         ]
 
 -- TODO: use forFileRecursive_


### PR DESCRIPTION
Fixes some packages that read extra-src-files in TH splices with
`hGetContents`, including `hledger` and `publicsuffix`.  Adds
`publicsuffix` as another test case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/pier/114)
<!-- Reviewable:end -->
