### PR TITLE
Add `pier setup` and some fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.cabal
 _pier/
 stackage/packages.txt
+stackage/pier.yaml

--- a/Readme.md
+++ b/Readme.md
@@ -190,6 +190,15 @@ files, as described [here](#build-outputs)), so that future builds will start
 from scratch.  Note that this command will require Pier to reinstall a local
 copy of GHC unless `system-ghc: true` is set.
 
+### `pier setup`
+`pier setup` downloads and configures the base build prerequisites.  This includes:
+- Downloading and preparing a local installation of GHC
+- Downloading and parsing the Stackage build plan
+- Parsing the local `pier.yaml` and `*.cabal` files.
+
+In general, it should not be necessary to run `pier setup` explicitly, since those
+steps are also performed automatically for other commands like `build`, `run` and `test`.
+
 ### Verbosity
 The `-V` command-line flag will make Pier more verbose.  It may be chained to increase verbosity (for example: `-VV`, `-V -V`, `-VVV`).
 


### PR DESCRIPTION
- Make `build-stackage.sh` more easily configurable.
- Add a `pier setup` command.
- Fix bugs in how common options were parsed before the command;
  previously such flags were just ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/pier/116)
<!-- Reviewable:end -->
